### PR TITLE
feat: improve StartHeartbeat

### DIFF
--- a/api_auth_test.go
+++ b/api_auth_test.go
@@ -31,21 +31,19 @@ func TestAuthTenantAccessTokenInternal(t *testing.T) {
 
 func TestHeartbeat(t *testing.T) {
 	bot := newTestBot()
-	bot.debugHeartbeat.Store(1)
 	assert.Nil(t, bot.heartbeat)
-	bot.StartHeartbeat()
-	time.Sleep(1 * time.Second)
+	assert.Nil(t, bot.startHeartbeat(time.Millisecond*900))
 	assert.NotEmpty(t, bot.tenantAccessToken)
-	assert.Equal(t, 1, bot.debugHeartbeat.Load().(int))
+	assert.Equal(t, int64(1), bot.heartbeatCounter)
 	time.Sleep(1 * time.Second)
-	assert.Equal(t, 2, bot.debugHeartbeat.Load().(int))
+	assert.Equal(t, int64(2), bot.heartbeatCounter)
 	bot.StopHeartbeat()
 	time.Sleep(2 * time.Second)
-	assert.Equal(t, 2, bot.debugHeartbeat.Load().(int))
+	assert.Equal(t, int64(2), bot.heartbeatCounter)
 	// restart heartbeat
-	bot.StartHeartbeat()
+	assert.Nil(t, bot.startHeartbeat(time.Millisecond*900))
 	time.Sleep(2 * time.Second)
-	assert.Equal(t, 3, bot.debugHeartbeat.Load().(int))
+	assert.Equal(t, int64(4), bot.heartbeatCounter)
 }
 
 func TestInvalidHeartbeat(t *testing.T) {

--- a/api_auth_test.go
+++ b/api_auth_test.go
@@ -50,6 +50,7 @@ func TestHeartbeat(t *testing.T) {
 
 func TestInvalidHeartbeat(t *testing.T) {
 	bot := NewNotificationBot("")
-	output := bot.captureOutput(func() { bot.StartHeartbeat() })
-	assert.Contains(t, output, "only support")
+	err := bot.StartHeartbeat()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "only support")
 }

--- a/lark.go
+++ b/lark.go
@@ -41,8 +41,8 @@ type Bot struct {
 	customClient    HTTPWrapper
 	// auth heartbeat
 	heartbeat chan bool
-	// auth heartbeat test utility integer
-	debugHeartbeat atomic.Value
+	// auth heartbeat counter (for testing)
+	heartbeatCounter int64
 
 	ctx    context.Context
 	logger LogWrapper
@@ -68,7 +68,6 @@ func NewChatBot(appID, appSecret string) *Bot {
 	}
 	bot.accessToken.Store("")
 	bot.tenantAccessToken.Store("")
-	bot.debugHeartbeat.Store(0)
 
 	return bot
 }
@@ -84,7 +83,6 @@ func NewNotificationBot(hookURL string) *Bot {
 	}
 	bot.accessToken.Store("")
 	bot.tenantAccessToken.Store("")
-	bot.debugHeartbeat.Store(0)
 
 	return bot
 }


### PR DESCRIPTION
Hi @crispgm , I also encounterd the #28 issue. The manually `GetTenantAccessTokenInternal(true)` call can be avoid if we do the first call in blocking mode. It's a common pattern to init and refresh a resource.

Closes #28 