### PR TITLE
supports to build multi-line rich text 

### DIFF
--- a/msg_post_builder_test.go
+++ b/msg_post_builder_test.go
@@ -1,6 +1,7 @@
 package lark
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,38 +26,38 @@ func TestPostTextTag(t *testing.T) {
 	pb := NewPostBuilder()
 	pb.TextTag("hello, world", 1, true)
 	buf := pb.CurLocale().Content
-	assert.Equal(t, "text", buf[0].Tag)
-	assert.Equal(t, "hello, world", *(buf[0].Text))
-	assert.Equal(t, 1, *(buf[0].Lines))
-	assert.Equal(t, true, *(buf[0].UnEscape))
+	assert.Equal(t, "text", buf[0][0].Tag)
+	assert.Equal(t, "hello, world", *(buf[0][0].Text))
+	assert.Equal(t, 1, *(buf[0][0].Lines))
+	assert.Equal(t, true, *(buf[0][0].UnEscape))
 }
 
 func TestPostLinkTag(t *testing.T) {
 	pb := NewPostBuilder()
 	pb.LinkTag("hello, world", "https://www.toutiao.com/")
 	buf := pb.CurLocale().Content
-	assert.Equal(t, "a", buf[0].Tag)
-	assert.Equal(t, "hello, world", *(buf[0].Text))
-	assert.Equal(t, "https://www.toutiao.com/", *(buf[0].Href))
+	assert.Equal(t, "a", buf[0][0].Tag)
+	assert.Equal(t, "hello, world", *(buf[0][0].Text))
+	assert.Equal(t, "https://www.toutiao.com/", *(buf[0][0].Href))
 }
 
 func TestPostAtTag(t *testing.T) {
 	pb := NewPostBuilder()
 	pb.AtTag("www", "123456")
 	buf := pb.CurLocale().Content
-	assert.Equal(t, "at", buf[0].Tag)
-	assert.Equal(t, "www", *(buf[0].Text))
-	assert.Equal(t, "123456", *(buf[0].UserID))
+	assert.Equal(t, "at", buf[0][0].Tag)
+	assert.Equal(t, "www", *(buf[0][0].Text))
+	assert.Equal(t, "123456", *(buf[0][0].UserID))
 }
 
 func TestPostImgTag(t *testing.T) {
 	pb := NewPostBuilder()
 	pb.ImageTag("d9f7d37e-c47c-411b-8ec6-9861132e6986", 320, 240)
 	buf := pb.CurLocale().Content
-	assert.Equal(t, "img", buf[0].Tag)
-	assert.Equal(t, "d9f7d37e-c47c-411b-8ec6-9861132e6986", *(buf[0].ImageKey))
-	assert.Equal(t, 240, *(buf[0].ImageHeight))
-	assert.Equal(t, 320, *(buf[0].ImageWidth))
+	assert.Equal(t, "img", buf[0][0].Tag)
+	assert.Equal(t, "d9f7d37e-c47c-411b-8ec6-9861132e6986", *(buf[0][0].ImageKey))
+	assert.Equal(t, 240, *(buf[0][0].ImageHeight))
+	assert.Equal(t, 320, *(buf[0][0].ImageWidth))
 }
 
 func TestPostClearAndLen(t *testing.T) {
@@ -81,7 +82,21 @@ func TestPostMultiLocaleContent(t *testing.T) {
 	assert.Equal(t, "en title", pb.CurLocale().Title)
 
 	content := pb.Render()
-	t.Log(content)
+	js, _ := json.Marshal(content)
+	t.Log(string(js))
 	assert.Equal(t, "中文标题", (*content)[LocaleZhCN].Title)
 	assert.Equal(t, "en title", (*content)[LocaleEnUS].Title)
+}
+
+func TestNewLine(t *testing.T) {
+	pb := NewPostBuilder()
+	pb.Title("中文标题")
+	pb.TextTag("你好世界", 1, true).TextTag("其他内容", 1, true)
+	pb.NewLine()
+	pb.TextTag("hello, world", 1, true).LinkTag("link", "https://www.toutiao.com/")
+	assert.Equal(t, 2, pb.Len())
+	assert.Equal(t, 2, pb.Lines())
+	content := pb.Render()
+	js, _ := json.Marshal(content)
+	t.Log(string(js))
 }


### PR DESCRIPTION
supports to build multi-line rich text (or say multi-segment rich text in a single post) by using NewLine() method, instead of using `\n` in a TextTag to start a new line.

See discuss on #42 

