### PR TITLE
feat(im): IMMessage use Sender rather than Sendor

### DIFF
--- a/api_message.go
+++ b/api_message.go
@@ -30,11 +30,11 @@ type IMMessageRequest struct {
 	UUID      string `json:"uuid,omitempty"`
 }
 
-// IMSendor .
-type IMSendor struct {
+// IMSender .
+type IMSender struct {
 	ID         string `json:"id"`
 	IDType     string `json:"id_type"`
-	SendorType string `json:"sendor_type"`
+	SenderType string `json:"sender_type"`
 	TenantKey  string `json:"tenant_key"`
 }
 
@@ -63,7 +63,7 @@ type IMMessage struct {
 	UpdateTime     string `json:"update_time"`
 	Deleted        bool   `json:"deleted"`
 	Updated        bool   `json:"updated"`
-	Sendor         IMSendor
+	Sender         IMSender
 	Mentions       []IMMention
 	Body           IMBody
 }


### PR DESCRIPTION
当前的开放平台接口版本中，字段名是Sender 而非 Sendor
![image](https://github.com/go-lark/lark/assets/33885148/cd40f8f8-b86d-4fec-8481-ca9ba10394c6)
参考[链接](https://open.feishu.cn/document/server-docs/im-v1/message/create)