### PR TITLE
feat(api): UploadBinaryFile support uploads binary file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v1.14.1
+- feat(api): UploadBinaryFile support uploads binary file
+
 ## v1.14.0
 
 - refactor(im): build reply and update message with standalone methods

--- a/api_upload_test.go
+++ b/api_upload_test.go
@@ -3,6 +3,7 @@ package lark
 import (
 	"image/jpeg"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,22 @@ func TestUploadFile(t *testing.T) {
 		FileType: "pdf",
 		FileName: "hello.pdf",
 		Path:     "./fixtures/test.pdf",
+	})
+	if assert.NoError(t, err) {
+		assert.Zero(t, resp.Code)
+		t.Log(resp.Data.FileKey)
+		assert.NotEmpty(t, resp.Data.FileKey)
+	}
+}
+
+func TestUploadBinaryFile(t *testing.T) {
+	resp, err := bot.UploadBinaryFile(UploadBinaryFileRequest{
+		FileType: "stream",
+		FileName: "test-data.csv",
+		Reader: strings.NewReader(`Name,Age,Location
+		Foo,25,Sleman
+		Bar,23,Sidoarjo
+		Baz,27,Bantul`),
 	})
 	if assert.NoError(t, err) {
 		assert.Zero(t, resp.Code)


### PR DESCRIPTION
We usually need to upload system generated virtual files that contains dynamic data.