### PR TITLE
fix(om/reply): set UUID on reply message

### DIFF
--- a/message_v2.go
+++ b/message_v2.go
@@ -32,8 +32,11 @@ func buildReplyMessage(om OutcomingMessage) (*IMMessageRequest, error) {
 	if req.Content == "" {
 		return nil, ErrMessageNotBuild
 	}
-	if om.ReplyInThread == true {
+	if om.ReplyInThread {
 		req.ReplyInThread = om.ReplyInThread
+	}
+	if om.UUID != "" {
+		req.UUID = om.UUID
 	}
 
 	return &req, nil


### PR DESCRIPTION
## Problem

I have set UUID on the `OutcomingMessage`, but the message is still duplicated.

## Investigation

`buildReplyMessage` does not set `UUID` like `BuildMessage`.

## Fix

set UUID on `buildReplyMessage`, similar to `BuildMessage`